### PR TITLE
Update debian/control

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,6 +1,6 @@
 Source: fty-service-status
 Maintainer: Clement Perrette <clementperrette@eaton.com>
-Build-Depends: cmake (>=3.0), debhelper (>= 9), catch2-dev
+Build-Depends: cmake (>=3.0), debhelper (>= 9), catch2
 Standards-Version: 1.0.0
 Section: devel
 Priority: extra


### PR DESCRIPTION
The "catch2-dev" was a local hack no longer used; update the recipe to require just "catch2" as the real distro calls it

Checked with D:10 and our local repackaging of 2.13.0 and D:T natively providing a 2.13.4